### PR TITLE
Adding support for ssh upstreams

### DIFF
--- a/problems/forks_and_clones/verify.js
+++ b/problems/forks_and_clones/verify.js
@@ -7,8 +7,10 @@ var exec = require('child_process').exec
 
 exec('git remote -v', function(err, stdout, stdrr) {
   var show = stdout.trim()
-  
-  if (show.match("upstream") && show.match("github.com/jlord/"))
+
+  if (show.match("upstream") && show.match("github.com[\:\/]jlord/")) {
     console.log("Upstream remote set up!")
-  else return console.log("No upstream remote")
+  } else {
+    return console.log("No upstream remote")
+  }
 })


### PR DESCRIPTION
Ran into the issue that if you use github remotes over ssh, it wouldn't recognize that in the tutorial when you added an upstream.

I think this is important because ssh should be the preferred way to handle remotes, so I fixed it.

Sorry about the extra curly brackets, the linter was driving my ocd insane if I didn't add them :o

Thanks otherwise for a great tutorial, looking forward to mentoring this thursday.
