### PR TITLE
Adjust superscript to center and avoid overlap

### DIFF
--- a/guide/assets/css/style.css
+++ b/guide/assets/css/style.css
@@ -274,9 +274,11 @@ n, v, adj {
 .superscript {
   font-size: 0.6em;
   position: absolute;
-  top: -20%;
+  bottom: 1.3em;
   line-height: 0.6em;
   font-weight: normal;
   white-space: nowrap;
   opacity: 0.8;
+  width: 100%
+  text-align: center;
 }


### PR DESCRIPTION
It was overlapping for me:
![2014-10-13 10 27 11](https://cloud.githubusercontent.com/assets/69736/4614923/10cc4bbe-52e5-11e4-802d-ae146a9bd643.png)


What about this:
![2014-10-13 10 25 46](https://cloud.githubusercontent.com/assets/69736/4614918/fa8751c8-52e4-11e4-9802-e905e500af76.png)
