### PR TITLE
Adds clarification to entering username

### DIFF
--- a/guide/raw-content/4_githubbin.html
+++ b/guide/raw-content/4_githubbin.html
@@ -18,7 +18,7 @@
 
       <h2>Step: Add username to Git</h2>
       <p>Add your GitHub username to your Git configuration,
-      which will be needed in order to verify the upcoming challenges. Save it exactly as you created it on GitHub — <strong>capitalize where capitalized</strong>.</p>
+      which will be needed in order to verify the upcoming challenges. Save it exactly as you created it on GitHub — <strong>capitalize where capitalized</strong>, and remember you don't need to enter the "&#60;" and "&#62;" .</p>
 
       <p>Add your GitHub username to your configuration:</p>
 


### PR DESCRIPTION
I've seen a few students make this mistake, and include the "<" and ">" here. I know you cover this in the [Tips for Getting Started](https://github.com/jlord/git-it#tips-for-getting-started) but it seems to be easy to overlook. :eyeglasses: 