### PR TITLE
Fixed typo in verify.js

### DIFF
--- a/problems/branches_arent_just_for_birds/verify.js
+++ b/problems/branches_arent_just_for_birds/verify.js
@@ -10,7 +10,7 @@ var username = ""
 // verify they've pushed
 // check the file is in contributors directory
 
-exec('git config user.username', function(err, stdout, stdrr) {
+exec('git config user.username', function(err, stdout, stderr) {
   if (err) return console.log(err)
   username = stdout.trim()
 


### PR DESCRIPTION
Hi jlord :)

I noticed a typo in the child_process.exec callback (stdrr instead of stderr). It wasn't causing any real problems (that I'm aware of), as I'm not sure we're really utilising stderr in this scenario. But the docs say (err, stdout, stderr) so I fixed it.

Sorry for being uber pedantic, but I'm trying to train myself to spot stuff like this.

Thanks for all your hard work on git-it and Node School!

Mike