### PR TITLE
fixed incorrect branchName check in tada

### DIFF
--- a/problems/merge_tada/verify.js
+++ b/problems/merge_tada/verify.js
@@ -17,8 +17,9 @@ exec('git reflog -10', function(err, stdout, stdrr) {
     
     exec('git branch', function(err, stdout, stdrr) {
       branches = stdout.trim()
-      
-      if (branches.match(user)) console.log("Uh oh, branch is still there.")
+      branchName = "add-"+user
+     
+      if (branches.match(branchName)) console.log("Uh oh, branch is still there.")
       else return console.log("Branch deleted!")
     })
   })


### PR DESCRIPTION
Tested using the tutorial; http://jlord.us/git-it/index.html resulting in an error. Git verified and did not pass the merge step initially because it was trying to check for the existence of a branch with the name `<username>`, whereas the tutorial suggested a branch with the name `add-<username>`. This fix has resolved that issue.