### PR TITLE
Fix `Commit to it` level, prevent the test to pass with a blank repo

### DIFF
--- a/problems/commit_to_it/verify.js
+++ b/problems/commit_to_it/verify.js
@@ -6,11 +6,14 @@ var exec = require('child_process').exec
 
 exec('git status', function(err, stdout, stdrr) {
   var show = stdout.trim()
-  
-  if (show.match("nothing to commit")) {
+
+  if (show.match("Initial commit")) {
+    console.log("Hmm, can't find\ncommitted changes.")
+  }
+  else if (show.match("nothing to commit")) {
     console.log("Changes have been committed!")
   }
-  else if (show.match("Changes not staged for commit")){
+  else {
     console.log("Seems there are changes\nto commit still.")
-  } else console.log("Hmm, can't find\ncommitted changes.")
+  }
 })


### PR DESCRIPTION
Hi @jlord,
Thank you for this great workshop.

I found that I was able to PASS this level without any commit in my repository, just after `git init`.