### PR TITLE
Changed LANG to 'C' for calling local lang

### DIFF
--- a/git-it.js
+++ b/git-it.js
@@ -3,7 +3,7 @@
 const Workshopper = require('workshopper-jlord'),
       path = require('path')
 
-process.env.LANG = 'en_US.UTF-8'
+process.env.LANG = 'C'
 
 Workshopper({
   name: 'git-it',


### PR DESCRIPTION
Problem: If the language package 'en_US.UTF-8' doesn't exist, then called the existing lang pack from OS. Example: I have my OS installed in German and git installed German, too. So doesn't work LANG='en_US.UTF-8'.
The solution: I set LANG to 'C' and this called the default language from git. So works the comparison with 'on Branch'.