### PR TITLE
Use bundled Lang pack, C

### DIFF
--- a/git-it.js
+++ b/git-it.js
@@ -3,7 +3,7 @@
 const Workshopper = require('workshopper-jlord'),
       path = require('path')
 
-process.env.LANG = 'en_US.UTF-8'
+process.env.LANG = 'C'
 
 Workshopper({
   name: 'git-it',


### PR DESCRIPTION
My understanding is that `en_US.UTF-8` isn't always on a user's system but `C` is, so this should be the fix for users who have Git in their native non-English language. 

Fixes #185 