### PR TITLE
Handling either *.name or *.username in gitconfig

### DIFF
--- a/problems/githubbin/verify.js
+++ b/problems/githubbin/verify.js
@@ -8,9 +8,9 @@ var user = ""
 // verify that user exists on GitHub (not case sensitve)
 // compare the two to make sure cases match
 
-exec('git config user.username', function(err, stdout, stderr) {
+exec('git config --list | grep user.*name', function(err, stdout, stderr) {
   if (err) return console.log(err)
-  user = stdout.trim()
+  user = stdout.replace(/user.*name=/, ' ').trim()
   if (user === "") console.error("No username found.")
   else {
     console.log("Username added to Git config!")


### PR DESCRIPTION
There might be a better way of handling this or even just switching to using `git config user.name` rather then `user.username` might help avoid trouble for users who have already setup git using official [git][1] or [github][2] documentation. Both of which seem to recommend `user.name` over `user.username`.  If there is some reason behind `user.username` being the better option, I'd love to learn more about the topic.

What got me to digging was I ran into the issue myself and started looking at the git docs and others .gitconfig files. The only thing I'm not 100% sure about is rather this would be a no go on a none POSIX systems. (no windows machine to test on, but works like a charm on OSX and Linux)

---
Thanks and great work on helping newbies level up we appreciate it!

[1]: http://www.git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup
[2]: https://help.github.com/articles/setting-your-username-in-git/