### PR TITLE
Log unexpected status codes in its_a_small_world

### DIFF
--- a/problems/its_a_small_world/verify.js
+++ b/problems/its_a_small_world/verify.js
@@ -16,10 +16,16 @@ exec('git config user.username', function(err, stdout, stdrr) {
 function collaborating(username) {
   request(url + username, {json: true}, function (error, response, body) {
     if (error) console.log(error)
-    if (!error && response.statusCode == 200) {
-      if (body.collab = true) console.log("Reporobot has been added!")
-      else console.log("Reporobot doesn't have access to the fork")
-      if (body.error) console.log(body)
+    if (!error) {
+      if (response.statusCode == 200) {
+        if (body.collab = true) console.log("Reporobot has been added!")
+        else console.log("Reporobot doesn't have access to the fork")
+        if (body.error) console.log(body)
+      }
+      else {
+        console.log("Unexpected HTTP status code accessing Reporobot server: " +
+          response.statusCode)
+      }
     }
   })
 }


### PR DESCRIPTION
When verifying this exercise I was getting the following result as reported in #209 and #176 with no error messages.

`"" != "Reporobot has been added!"`

After a bit of digging I realised I was getting a 403 because of my firewall. I thought if the status code was logged it could prompt users in the right direction.

Not sure about the wording though, or if it should check specifically for 403s and make a suggestion about checking firewall or proxy settings.

Also thanks for the cool workshop! I did it a second time for fun :)