### PR TITLE
Fix html reserved chars and other minor typos

### DIFF
--- a/guide/challenges-zhtw/branches_arent_just_for_birds.html
+++ b/guide/challenges-zhtw/branches_arent_just_for_birds.html
@@ -112,7 +112,7 @@
 
         <h4><n><span class="superscript">&#x5206;&#x652F;</span>Branch</n> name expected: _____</h4>
         <p><n><span class="superscript">&#x5206;&#x652F;</span>Branch</n> &#x7684;&#x540D;&#x5B57;&#x61C9;&#x8A72;&#x8981;&#x8DDF;&#x4F60;&#x7684;&#x5E33;&#x865F;&#x540D;&#x7A31;&#x4E00;&#x6A21;&#x4E00;&#x6A23;&#x3002;&#x7528;&#x4EE5;&#x4E0B;&#x7684;&#x6307;&#x4EE4;&#x4FEE;&#x6539; <n><span class="superscript">&#x5206;&#x652F;</span>branch</n> &#x7684;&#x540D;&#x5B57;&#xFF1A;</p>
-        <p><code>$ git branch -M &lt;NEWBRANCHNAME&gt;</code></p>
+        <p><code>$ git branch -m &lt;NEWBRANCHNAME&gt;</code></p>
         <p>&#x5B8C;&#x6210;&#x4EE5;&#x4E0A;&#x7684;&#x52D5;&#x4F5C;&#x4E4B;&#x5F8C;&#xFF0C;&#x518D;&#x57F7;&#x884C;&#x4E00;&#x6B21; <code>git-it verify</code>&#xFF01;</p>
       </div>
 

--- a/guide/challenges-zhtw/remote_control.html
+++ b/guide/challenges-zhtw/remote_control.html
@@ -117,15 +117,15 @@
         <h2>&#x6487;&#x6B65;</h2>
         <ul>
           <li><strong>&#x65B0;&#x589E; <n><span class="superscript">&#x9060;&#x7AEF;</span>remote</n> &#x9023;&#x7D50;</strong></li>
-          <code>$ git remote add &lt;REMOTENAME&gt; <url></url></code>
+          <code>$ git remote add &lt;REMOTENAME&gt; &lt;URL&gt;</code>
           <li><strong>&#x5E6B;&#x4E00;&#x500B; <n><span class="superscript">&#x9060;&#x7AEF;</span>remote</n> &#x8A2D;&#x5B9A;&#x4F4D;&#x5740;</strong></li>
-          <code>$ git remote set-url &lt;REMOTENAME&gt; <url></url></code>
+          <code>$ git remote set-url &lt;REMOTENAME&gt; &lt;URL&gt;</code>
           <li><strong><v><span class="superscript">&#x6536;&#x53D6;</span>Pull</v> <n><span class="superscript">&#x9060;&#x7AEF;</span>remote</n> &#x7684;&#x7A0B;&#x5F0F;</strong></li>
           <code>$ git pull &lt;REMOTENAME&gt; &lt;BRANCHNAME&gt;</code>
           <li><strong>&#x770B;&#x4F60;&#x6709;&#x54EA;&#x4E9B; <n><span class="superscript">&#x9060;&#x7AEF;</span>remote</n> &#x9023;&#x7D50;</strong></li>
           <code>$ git remote -v</code>
           <li><strong><v><span class="superscript">&#x63A8;&#x9001;</span>Push</v> &#x96FB;&#x8166;&#x4E0A;&#x7684;&#x7A0B;&#x5F0F;&#x5230; <n><span class="superscript">&#x9060;&#x7AEF;</span>remote</n></strong></li>
-          <code>$ git push &lt;REMOTENAME&gt; <branch></branch></code>
+          <code>$ git push &lt;REMOTENAME&gt; &lt;BRANCH&gt;</code>
         </ul>
       </div>
 

--- a/guide/challenges/branches_arent_just_for_birds.html
+++ b/guide/challenges/branches_arent_just_for_birds.html
@@ -124,7 +124,7 @@
 
         <h4>Branch name expected: _____</h4>
         <p>The branch name should match your user name exactly. To change your branch name:</p>
-        <p><code>$ git branch -M &#60;NEWBRANCHNAME&#62;</code></p>
+        <p><code>$ git branch -m &#60;NEWBRANCHNAME&#62;</code></p>
         <p>When you've made your updates, verify again!</p>
       </div>
 

--- a/guide/dictionary.html
+++ b/guide/dictionary.html
@@ -86,7 +86,7 @@
           <li><strong>Add remote connections</strong></li>
           <code>$ git remote add &#60;REMOTENAME&#62; &#60;URL&#62;</code>
           <li><strong>Set a URL to a remote</strong></li>
-          <code>$ git remote set-url &#60;REMOTENAME&#62; <URL></code>
+          <code>$ git remote set-url &#60;REMOTENAME&#62; &#60;URL&#62;</code>
           <li><strong>View remote connections</strong></li>
           <code>$ git remote -v</code>
         </ul>
@@ -96,9 +96,9 @@
       <div id="git-tips">
         <ul>
           <li><strong>Pull in changes</strong></li>
-          <code>$ git pull &#60;REMOTENAME&#62; &#60;BRANCHNAME&#62;</code>
+          <code>$ git pull</code>
           <li><strong>Pull in changes from a remote branch</strong></li>
-          <code>$ git pull <REMOTENAME> <REMOTEBRANCH></code>
+          <code>$ git pull &#60;REMOTENAME&#62; &#60;REMOTEBRANCH&#62;</code>
           <li><strong>See changes to the remote before you pull in</strong></li>
           <code>$ git fetch --dry-run</code>
         </ul>
@@ -108,7 +108,7 @@
       <div id="git-tips">
         <ul>
           <li><strong>Push changes</strong></li>
-          <code>$ git push &#60;REMOTENAME&#62; <BRANCH></code>
+          <code>$ git push &#60;REMOTENAME&#62; &#60;BRANCHNAME&#62;</code>
           <li><strong>Merge a branch into current branch</strong></li>
           <code>$ git merge &#60;BRANCHNAME&#62;</code>
         </ul>

--- a/guide/raw-content-zhtw/5_remote_control.html
+++ b/guide/raw-content-zhtw/5_remote_control.html
@@ -74,14 +74,14 @@
         <h2>撇步</h2>
         <ul>
           <li><strong>新增 <n>remote</n> 連結</strong></li>
-          <code>$ git remote add &#60;REMOTENAME&#62; <URL></code>
+          <code>$ git remote add &#60;REMOTENAME&#62; &#60;URL&#62;</code>
           <li><strong>幫一個 <n>remote</n> 設定位址</strong></li>
-          <code>$ git remote set-url &#60;REMOTENAME&#62; <URL></code>
+          <code>$ git remote set-url &#60;REMOTENAME&#62; &#60;URL&#62;</code>
           <li><strong><v>Pull</v> <n>remote</n> 的程式</strong></li>
           <code>$ git pull &#60;REMOTENAME&#62; &#60;BRANCHNAME&#62;</code>
           <li><strong>看你有哪些 <n>remote</n> 連結</strong></li>
           <code>$ git remote -v</code>
           <li><strong><v>Push</v> 電腦上的程式到 <n>remote</n></strong></li>
-          <code>$ git push &#60;REMOTENAME&#62; <BRANCH></code>
+          <code>$ git push &#60;REMOTENAME&#62; &#60;BRANCH&#62;</code>
         </ul>
       </div>

--- a/guide/raw-content-zhtw/7_branches_arent_just_for_birds.html
+++ b/guide/raw-content-zhtw/7_branches_arent_just_for_birds.html
@@ -69,7 +69,7 @@
 
         <h4><n>Branch</n> name expected: _____</h4>
         <p><n>Branch</n> 的名字應該要跟你的帳號名稱一模一樣。用以下的指令修改 <n>branch</n> 的名字：</p>
-        <p><code>$ git branch -M &#60;NEWBRANCHNAME&#62;</code></p>
+        <p><code>$ git branch -m &#60;NEWBRANCHNAME&#62;</code></p>
         <p>完成以上的動作之後，再執行一次 <code>git-it verify</code>！</p>
       </div>
 

--- a/guide/raw-content/6_forks_and_clones.html
+++ b/guide/raw-content/6_forks_and_clones.html
@@ -22,7 +22,7 @@
       <h2>Step: Fork Patchwork Repository</h2>
       <p>The project we'll work with is <a href="http://github.com/jlord/patchwork" target="_blank">github.com/jlord/patchwork</a>. Go to that site and click the fork button at the top right. Once the
         fork animation is complete, you've got a copy on your account. Copy
-        your fork's HTTP URL on the right sidebar.</p>
+        your fork's HTTP URL from the repo's address bar. <br><img src="https://help.github.com/assets/images/help/repository/clone-repo-clone-url-button.png">.</p>
 
       <h2>Step: Clone Fork Locally</h2>
       <p>Now, in terminal, clone the repository onto your computer. It will create a new folder

--- a/guide/raw-content/7_branches_arent_just_for_birds.html
+++ b/guide/raw-content/7_branches_arent_just_for_birds.html
@@ -81,7 +81,7 @@
 
         <h4>Branch name expected: _____</h4>
         <p>The branch name should match your user name exactly. To change your branch name:</p>
-        <p><code>$ git branch -M &#60;NEWBRANCHNAME&#62;</code></p>
+        <p><code>$ git branch -m &#60;NEWBRANCHNAME&#62;</code></p>
         <p>When you've made your updates, verify again!</p>
       </div>
 

--- a/help.txt
+++ b/help.txt
@@ -97,7 +97,7 @@
 
   $ cd ..
 
-  {bold}Back out all the way to the root directory{/bold}
+  {bold}Back out all the way to the home directory{/bold}
 
   $ cd
 
@@ -112,4 +112,3 @@
   {bold}Remove (delete) a folder{/bold}
 
   $ rm -rf <FOLDERNAME>
-


### PR DESCRIPTION
In guide html pages, the text of some git command parameters disappear when rendered in browser because reserved chars aren't escaped as char references.
Included also some commits with minor typo or wording fixes.