### PR TITLE
🔧site width on mobile

### DIFF
--- a/guide/assets/css/style.css
+++ b/guide/assets/css/style.css
@@ -44,7 +44,7 @@ li {
 }
 
 .wrapper {
-  width: 600px;
+  max-width: 600px;
   margin: 30px auto;
   padding: 0 20px;
 }


### PR DESCRIPTION
http://jlord.us/git-it/ on mobile has a vertical scroll because it's got a giant width. I couldn't figure out how to run this locally, but I did inspect the live site and applied this change and it looked fine. 🙃

Before: (look, it's scrolled!)
<img width="335" alt="screen shot 2016-08-23 at 10 35 32 am" src="https://cloud.githubusercontent.com/assets/1369170/17902754/6beaaf54-691d-11e6-8d2f-0e7e0a121db4.png">

After:
<img width="334" alt="screen shot 2016-08-23 at 10 35 49 am" src="https://cloud.githubusercontent.com/assets/1369170/17902758/720c5bb2-691d-11e6-8aa1-628dce2f4c99.png">
