### PR TITLE
Added support for user.name in Githubbin lesson

### DIFF
--- a/guide/challenges/githubbin.html
+++ b/guide/challenges/githubbin.html
@@ -27,7 +27,7 @@
       </a>
     </div>
   </div>
-  
+
   <div class="wrapper">
     <div class="u-floatLeft">
       <span class="all-caps">CHALLENGE</span>

--- a/guide/raw-content/4_githubbin.html
+++ b/guide/raw-content/4_githubbin.html
@@ -22,7 +22,7 @@
 
       <p>Add your GitHub username to your configuration:</p>
 
-      <code>$ git config --global user.username &#60;USerNamE&#62;</code>
+      <code>$ git config --global user.name &#60;USerNamE&#62;</code>
       <br><br>
 
       <div class="verify">

--- a/problems/githubbin/verify.js
+++ b/problems/githubbin/verify.js
@@ -8,8 +8,30 @@ var user = ""
 // verify that user exists on GitHub (not case sensitve)
 // compare the two to make sure cases match
 
+function verify(err, stdout, stderr) {
+  if (err) return console.log(err);
+  user = stdout.trim()
+  if (user === "") console.error("No username found.")
+  else {
+    console.log("Username added to Git config!")
+    checkGitHub(user)
+  }
+}
+
+// Update: user.name is now the standard, not user.username
+// Both are still supported here, though.
 exec('git config user.username', function(err, stdout, stderr) {
-  if (err) return console.log(err)
+  if (err) {
+    // Is the error because they don't have a user.username field in git config?
+    var noUserUsername = err.toString().includes("Command failed: git config user.username");
+    if (noUserUsername) {
+      exec('git config user.name', verify);
+      return;
+    } else {
+      return console.log(err);
+    }
+  }
+  // Still works if they have user.username
   user = stdout.trim()
   if (user === "") console.error("No username found.")
   else {


### PR DESCRIPTION
Hi,

Evidently the normal field for a GitHub username in git config is now user.name instead of user.username. (Docs at https://git-scm.com/docs/git-config#git-config-username.)

Just noticed this since I had already been using GitHub and I already had a user.name field, but no user.username field. It seems redundant to have users set both, especially when one is outdated.

I've updated the verify script for Githubbin to accept values for either field if the user has them. Also updated the raw-content guide page for the Githubbin lesson.

Didn't actually make any changes to the guide/challenges/githubbin.html file, as requested in the contribution guidelines.

Thanks,
Travis