### PR TITLE
fixed "branches aren't just for birds" exercise to work properly with git2+

### DIFF
--- a/problems/branches_arent_just_for_birds/verify.js
+++ b/problems/branches_arent_just_for_birds/verify.js
@@ -10,7 +10,7 @@ var username = ""
 // verify they've pushed
 // check the file is in contributors directory
 
-exec('git config user.username', function(err, stdout, stderr) {
+exec('git config user.name', function(err, stdout, stderr) {
   if (err) return console.log(err)
   username = stdout.trim()
 


### PR DESCRIPTION
Well, I found out that command 'github config user.username' is no longer used to show username, and because of it the challenge could not be completed. I simply changed the command to currently used one and it works as it should.