### PR TITLE
Updated where add-username.txt file is to be saved.

### DIFF
--- a/guide/challenges-zhtw/branches_arent_just_for_birds.html
+++ b/guide/challenges-zhtw/branches_arent_just_for_birds.html
@@ -80,7 +80,7 @@
         <ul>
           <li>&#x65B0;&#x589E;&#x4E00;&#x500B;&#x6A94;&#x6848;&#x4E26;&#x547D;&#x540D;&#x70BA; <span style="white-space: nowrap;">&#x300C;add-&lt;USERNAME&gt;.txt&#x300D;</span>&#xFF0C;&#x8ACB;&#x7528;&#x4F60;&#x7684;&#x5E33;&#x865F;&#x540D;&#x7A31;&#x66FF;&#x63DB; &apos;username&apos;&#xFF0C;&#x50CF;&#x9019;&#x6A23;&#xFF0C;&#x300C;add-jlord.txt&#x300D;&#x3002;</li>
           <li>&#x5728;&#x6A94;&#x6848;&#x88E1;&#x5BEB;&#x4E0B;&#x4F60;&#x7684; GitHub &#x5E33;&#x865F;&#x540D;&#x7A31;&#x3002;&#x4F8B;&#x5982;&#xFF0C;&#x6211;&#x5C31;&#x6703;&#x5BEB; &apos;jlord&apos;&#x3002;</li>
-          <li>&#x5C07;&#x6A94;&#x6848;&#x5B58;&#x5230;&#x5728; patchwork &#x88E1;&#x7684; &apos;contributors&apos; &#x8CC7;&#x6599;&#x593E;&#xFF1A; <strong>patchwork/contributors/add-yourusername.txt</strong></li>
+          <li>&#x5C07;&#x6A94;&#x6848;&#x5B58;&#x5230;&#x5728; patchwork &#x88E1;&#x7684; &apos;contributors&apos; &#x8CC7;&#x6599;&#x593E;&#xFF1A; <strong>contributors/add-yourusername.txt</strong></li>
           <li>&#x63A5;&#x8457;&#xFF0C;&#x628A;&#x4F60;&#x7684;&#x4FEE;&#x6539;&#x8A18;&#x9304;&#x4E0B;&#x4F86;&#xFF01;</li>
         </ul>
 

--- a/guide/challenges/branches_arent_just_for_birds.html
+++ b/guide/challenges/branches_arent_just_for_birds.html
@@ -94,7 +94,7 @@
           <li>Then, just write your
         GitHub username in it, that's it and that's all. For instance,
         I'd type 'jlord'.</li>
-          <li>Save this file in the 'contributors' folder in patchwork: <strong>patchwork/contributors/add-yourusername.txt</strong></li>
+          <li>Save this file in the 'contributors' folder in patchwork: <strong>contributors/add-yourusername.txt</strong></li>
           <li>Next, check in your changes!</li>
         </ul>
 

--- a/guide/raw-content-zhtw/7_branches_arent_just_for_birds.html
+++ b/guide/raw-content-zhtw/7_branches_arent_just_for_birds.html
@@ -37,7 +37,7 @@
         <ul>
           <li>新增一個檔案並命名為 <span style="white-space: nowrap;">「add-&#60;USERNAME&#62;.txt」</span>，請用你的帳號名稱替換 'username'，像這樣，「add-jlord.txt」。</li>
           <li>在檔案裡寫下你的 GitHub 帳號名稱。例如，我就會寫 'jlord'。</li>
-          <li>將檔案存到在 patchwork 裡的 'contributors' 資料夾： <strong>patchwork/contributors/add-yourusername.txt</strong></li>
+          <li>將檔案存到在 patchwork 裡的 'contributors' 資料夾： <strong>contributors/add-yourusername.txt</strong></li>
           <li>接著，把你的修改記錄下來！</li>
         </ul>
 

--- a/guide/raw-content/7_branches_arent_just_for_birds.html
+++ b/guide/raw-content/7_branches_arent_just_for_birds.html
@@ -51,7 +51,7 @@
           <li>Then, just write your
         GitHub username in it, that's it and that's all. For instance,
         I'd type 'jlord'.</li>
-          <li>Save this file in the 'contributors' folder in patchwork: <strong>patchwork/contributors/add-yourusername.txt</strong></li>
+          <li>Save this file in the 'contributors' folder in patchwork: <strong>contributors/add-yourusername.txt</strong></li>
           <li>Next, check in your changes!</li>
         </ul>
 


### PR DESCRIPTION
In the `git-it` tutorial it states that the `add-yourusername.txt` file should
be saved in the `Patchwork/contributors/` directory. However, this
raises an error when the user goes to verify their work. In order for
this challenge to pass, the user must save their file in the
`CONTRIBUTORS/` directory instead.

I grep'd your repo in an effort to determine where these changes
should be made. Hopefully I changed it in all the right places...

Thanks for putting this tutorial together.